### PR TITLE
Use new extension API to access setting

### DIFF
--- a/web/monitor.ts
+++ b/web/monitor.ts
@@ -560,7 +560,7 @@ class CrystoolsMonitor {
     const currentRate =
       parseFloat(app.ui.settings.getSettingValue(this.settingsRate.id, this.settingsRate.defaultValue));
 
-    this.menuDisplayOption = app.ui.settings.getSettingValue(ComfyKeyMenuDisplayOption, MenuDisplayOptions.Disabled);
+    this.menuDisplayOption = app.extensionManager.setting.get(ComfyKeyMenuDisplayOption);
     app.ui.settings.addEventListener(`${ComfyKeyMenuDisplayOption}.change`, (e: any) => {
         this.updateDisplay(e.detail.value);
       },


### PR DESCRIPTION
Resolves https://github.com/crystian/ComfyUI-Crystools/issues/147

Use new extension API to access setting so that default value of setting is properly handled.

Do note that the new extension API is only available v1.3.22 frontend. See details here: https://github.com/Comfy-Org/ComfyUI_frontend#developer-apis