### PR TITLE
Fix display bars

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,15 +8,27 @@
 """
 
 from .core import version, logger
-logger.info(f'Crystools version: {version}')
+
+logger.info(f"Crystools version: {version}")
 
 from .nodes._names import CLASSES
 from .nodes.primitive import CBoolean, CText, CTextML, CInteger, CFloat
-from .nodes.switch import CSwitchBooleanAny, CSwitchBooleanLatent, CSwitchBooleanConditioning, CSwitchBooleanImage, \
-  CSwitchBooleanString, CSwitchBooleanMask
+from .nodes.switch import (
+    CSwitchBooleanAny,
+    CSwitchBooleanLatent,
+    CSwitchBooleanConditioning,
+    CSwitchBooleanImage,
+    CSwitchBooleanString,
+    CSwitchBooleanMask,
+)
 from .nodes.debugger import CConsoleAny, CConsoleAnyToJson
-from .nodes.image import CImagePreviewFromImage, CImageLoadWithMetadata, CImageGetResolution, CImagePreviewFromMetadata, \
-    CImageSaveWithExtraMetadata
+from .nodes.image import (
+    CImagePreviewFromImage,
+    CImageLoadWithMetadata,
+    CImageGetResolution,
+    CImagePreviewFromMetadata,
+    CImageSaveWithExtraMetadata,
+)
 from .nodes.list import CListAny, CListString
 from .nodes.pipe import CPipeToAny, CPipeFromAny
 from .nodes.utils import CUtilsCompareJsons, CUtilsStatSystem
@@ -31,29 +43,23 @@ NODE_CLASS_MAPPINGS = {
     CLASSES.CTEXTML_NAME.value: CTextML,
     CLASSES.CINTEGER_NAME.value: CInteger,
     CLASSES.CFLOAT_NAME.value: CFloat,
-
     CLASSES.CDEBUGGER_CONSOLE_ANY_NAME.value: CConsoleAny,
     CLASSES.CDEBUGGER_CONSOLE_ANY_TO_JSON_NAME.value: CConsoleAnyToJson,
-
     CLASSES.CLIST_ANY_NAME.value: CListAny,
     CLASSES.CLIST_STRING_NAME.value: CListString,
-
     CLASSES.CSWITCH_ANY_NAME.value: CSwitchBooleanAny,
     CLASSES.CSWITCH_LATENT_NAME.value: CSwitchBooleanLatent,
     CLASSES.CSWITCH_CONDITIONING_NAME.value: CSwitchBooleanConditioning,
     CLASSES.CSWITCH_IMAGE_NAME.value: CSwitchBooleanImage,
     CLASSES.CSWITCH_MASK_NAME.value: CSwitchBooleanMask,
     CLASSES.CSWITCH_STRING_NAME.value: CSwitchBooleanString,
-
     CLASSES.CPIPE_TO_ANY_NAME.value: CPipeToAny,
     CLASSES.CPIPE_FROM_ANY_NAME.value: CPipeFromAny,
-
     CLASSES.CIMAGE_LOAD_METADATA_NAME.value: CImageLoadWithMetadata,
     CLASSES.CIMAGE_GET_RESOLUTION_NAME.value: CImageGetResolution,
     CLASSES.CIMAGE_PREVIEW_IMAGE_NAME.value: CImagePreviewFromImage,
     CLASSES.CIMAGE_PREVIEW_METADATA_NAME.value: CImagePreviewFromMetadata,
     CLASSES.CIMAGE_SAVE_METADATA_NAME.value: CImageSaveWithExtraMetadata,
-
     CLASSES.CMETADATA_EXTRACTOR_NAME.value: CMetadataExtractor,
     CLASSES.CMETADATA_COMPARATOR_NAME.value: CMetadataCompare,
     CLASSES.CUTILS_JSON_COMPARATOR_NAME.value: CUtilsCompareJsons,
@@ -68,38 +74,31 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     CLASSES.CTEXTML_NAME.value: CLASSES.CTEXTML_DESC.value,
     CLASSES.CINTEGER_NAME.value: CLASSES.CINTEGER_DESC.value,
     CLASSES.CFLOAT_NAME.value: CLASSES.CFLOAT_DESC.value,
-
     CLASSES.CDEBUGGER_CONSOLE_ANY_NAME.value: CLASSES.CDEBUGGER_ANY_DESC.value,
     CLASSES.CDEBUGGER_CONSOLE_ANY_TO_JSON_NAME.value: CLASSES.CDEBUGGER_CONSOLE_ANY_TO_JSON_DESC.value,
-
     CLASSES.CLIST_ANY_NAME.value: CLASSES.CLIST_ANY_DESC.value,
     CLASSES.CLIST_STRING_NAME.value: CLASSES.CLIST_STRING_DESC.value,
-
     CLASSES.CSWITCH_ANY_NAME.value: CLASSES.CSWITCH_ANY_DESC.value,
     CLASSES.CSWITCH_LATENT_NAME.value: CLASSES.CSWITCH_LATENT_DESC.value,
     CLASSES.CSWITCH_CONDITIONING_NAME.value: CLASSES.CSWITCH_CONDITIONING_DESC.value,
     CLASSES.CSWITCH_IMAGE_NAME.value: CLASSES.CSWITCH_IMAGE_DESC.value,
     CLASSES.CSWITCH_MASK_NAME.value: CLASSES.CSWITCH_MASK_DESC.value,
     CLASSES.CSWITCH_STRING_NAME.value: CLASSES.CSWITCH_STRING_DESC.value,
-
     CLASSES.CPIPE_TO_ANY_NAME.value: CLASSES.CPIPE_TO_ANY_DESC.value,
     CLASSES.CPIPE_FROM_ANY_NAME.value: CLASSES.CPIPE_FROM_ANY_DESC.value,
-
     CLASSES.CIMAGE_LOAD_METADATA_NAME.value: CLASSES.CIMAGE_LOAD_METADATA_DESC.value,
     CLASSES.CIMAGE_GET_RESOLUTION_NAME.value: CLASSES.CIMAGE_GET_RESOLUTION_DESC.value,
     CLASSES.CIMAGE_PREVIEW_IMAGE_NAME.value: CLASSES.CIMAGE_PREVIEW_IMAGE_DESC.value,
     CLASSES.CIMAGE_PREVIEW_METADATA_NAME.value: CLASSES.CIMAGE_PREVIEW_METADATA_DESC.value,
     CLASSES.CIMAGE_SAVE_METADATA_NAME.value: CLASSES.CIMAGE_SAVE_METADATA_DESC.value,
-
     CLASSES.CMETADATA_EXTRACTOR_NAME.value: CLASSES.CMETADATA_EXTRACTOR_DESC.value,
     CLASSES.CMETADATA_COMPARATOR_NAME.value: CLASSES.CMETADATA_COMPARATOR_DESC.value,
-
     CLASSES.CUTILS_JSON_COMPARATOR_NAME.value: CLASSES.CUTILS_JSON_COMPARATOR_DESC.value,
     CLASSES.CUTILS_STAT_SYSTEM_NAME.value: CLASSES.CUTILS_STAT_SYSTEM_DESC.value,
-
     CLASSES.CJSONFILE_NAME.value: CLASSES.CJSONFILE_DESC.value,
     CLASSES.CJSONEXTRACTOR_NAME.value: CLASSES.CJSONEXTRACTOR_DESC.value,
 }
 
 
 WEB_DIRECTORY = "./web"
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]


### PR DESCRIPTION
A ComfyUI update seems to have broken the display of the bars as mentioned in #163 and #160.

According to https://docs.comfy.org/custom-nodes/javascript_overview#exporting-web-directory,
`__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]` is needed and it was missing.

I tested this change on a completely fresh ComfyUI install by manual cloning and via the manager with the repo URL. 