### PR TITLE
parse str to json

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -110,6 +110,8 @@ def get_size(path):
 def get_nested_value(data, dotted_key, default=None):
   keys = dotted_key.split('.')
   for key in keys:
+    if isinstance(data, str):
+        data = json.loads(data)
     if isinstance(data, dict) and key in data:
       data = data[key]
     else:


### PR DESCRIPTION
Sometimes "JSON extractor" would end up with a str even though it got the data from "metadata extractor"