### PR TITLE
[Urgent] Change node name to case sensitive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "comfyui-crystools"
+name = "ComfyUI-Crystools"
 description = "With this suit, you can see the resources monitor, progress bar & time elapsed, metadata and compare between two images, compare between two JSONs, show any value to console/display, pipes, and more!\nThis provides better nodes to load/save images, previews, etc, and see \"hidden\" data without loading a new workflow."
 version = "1.22.0"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Hey! Robin from Comfy Org here. Manager currently installs custom nodes into the `custom_nodes` directory with the same name as the node id in `pyproject.toml`. This causes some issues with frontend assets that are accessed via the comfy server API. 

On windows, since paths are case sensitive, this breaks the crystools extension. 

Can you merge this PR? I will update the node on registry to have the same node id.