### PR TITLE
fix: update text for custom_modules to custom_nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ You have predefined switches (string, latent, image, conditioning) but you can u
 
 ### Install from GitHub
 1. Install [ComfyUi](https://github.com/comfyanonymous/ComfyUI).
-2. Clone this repo into `custom_modules`:
+2. Clone this repo into `custom_nodes`:
     ```
     cd ComfyUI/custom_nodes
     git clone https://github.com/crystian/ComfyUI-Crystools.git


### PR DESCRIPTION
Original README.md states to install into custom_modules folder (confused me for a moment).

This text here should indicate as custom_nodes.