### PR TITLE
removed superfluous zluda check

### DIFF
--- a/general/gpu.py
+++ b/general/gpu.py
@@ -81,6 +81,12 @@ class CGPUInfo:
         except Exception as e:
             logger.error('Could not pick default device. ' + str(e))
 
+        if self.pynvmlLoaded and not self.jtopLoaded and not self.deviceGetCount():
+            logger.warning('No GPU detected, disabling GPU monitoring.')
+            self.anygpuLoaded = False
+            self.pynvmlLoaded = False
+            self.jtopLoaded = False
+
         if self.anygpuLoaded:
             if self.deviceGetCount() > 0:
                 self.cudaDevicesFound = self.deviceGetCount()


### PR DESCRIPTION
As per https://github.com/crystian/comfyui-crystools/issues/216 and to a somewhat lesser extent, the rather confused https://github.com/crystian/comfyui-crystools/issues/80, I have removed the ZLUDA check from `gpu.py`.

I have replaced it with a more functional test:
```py
    if self.pynvmlLoaded and not self.jtopLoaded and not self.deviceGetCount():
        logger.warning('No GPU detected, disabling GPU monitoring.')
        self.anygpuLoaded = False
        self.pynvmlLoaded = False
        self.jtopLoaded = False
```

Thus, if `pynvml` does manage to load (which I assume it will, since it's a package requirement), but cannot find any nvidia devices, it will gracefully cease monitoring.  If a Jetson is found, then this test will not occur.   That would seem to safely cover all bases.

This permits ZLUDA users the opportunity to develop and test `pynvml` shims, without adversely affecting other users.
